### PR TITLE
fix setting tap position for two windings transformer modification

### DIFF
--- a/src/main/java/org/gridsuite/modification/modifications/TwoWindingsTransformerModification.java
+++ b/src/main/java/org/gridsuite/modification/modifications/TwoWindingsTransformerModification.java
@@ -691,10 +691,10 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
         }
 
         ReportNode lowTapPositionReportNode = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
-            isModification ? tapChanger::setLowTapPosition
-                : tapChangerAdder::setLowTapPosition,
-            isModification ? tapChanger::getLowTapPosition : () -> null,
-            modifyLowTapPosition, "Low tap position");
+                isModification ? tapChanger::setLowTapPosition
+                        : tapChangerAdder::setLowTapPosition,
+                isModification ? tapChanger::getLowTapPosition : () -> null,
+                modifyLowTapPosition, "Low tap position");
 
         // must be done after setting the low position and the steps
         ReportNode tapPositionReportNode = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(


### PR DESCRIPTION
the setting of tap position is currently set before the steps are set so it crashes when setting a postion out of the older number of taps