### PR TITLE
fix copying limits on LinesAttachToSplitLines

### DIFF
--- a/src/main/java/org/gridsuite/modification/modifications/LinesAttachToSplitLines.java
+++ b/src/main/java/org/gridsuite/modification/modifications/LinesAttachToSplitLines.java
@@ -59,17 +59,18 @@ public class LinesAttachToSplitLines extends AbstractModification {
 
     @Override
     public void apply(Network network, ReportNode subReportNode) {
+        // TODO remove when powsybl core handles it, probably release of june 2026
         Line line1 = network.getLine(modificationInfos.getLineToAttachTo1Id());
         String selectedOperationalLimitsGroup1Line1 = line1.getSelectedOperationalLimitsGroupId1().orElse(null);
         String selectedOperationalLimitsGroup2Line1 = line1.getSelectedOperationalLimitsGroupId2().orElse(null);
         Collection<OperationalLimitsGroup> operationalLimitsGroups1Line1 = line1.getOperationalLimitsGroups1();
         Collection<OperationalLimitsGroup> operationalLimitsGroups2Line1 = line1.getOperationalLimitsGroups2();
-
         Line line2 = network.getLine(modificationInfos.getLineToAttachTo2Id());
         String selectedOperationalLimitsGroup1Line2 = line2.getSelectedOperationalLimitsGroupId1().orElse(null);
         String selectedOperationalLimitsGroup2Line2 = line2.getSelectedOperationalLimitsGroupId2().orElse(null);
         Collection<OperationalLimitsGroup> operationalLimitsGroups1Line2 = line2.getOperationalLimitsGroups1();
         Collection<OperationalLimitsGroup> operationalLimitsGroups2Line2 = line2.getOperationalLimitsGroups2();
+
         ReplaceTeePointByVoltageLevelOnLine algo = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1(modificationInfos.getLineToAttachTo1Id())
                 .withTeePointLine2(modificationInfos.getLineToAttachTo2Id())
@@ -81,6 +82,7 @@ public class LinesAttachToSplitLines extends AbstractModification {
                 .withNewLine2Name(modificationInfos.getReplacingLine2Name())
                 .build();
         algo.apply(network, true, subReportNode);
+        // TODO remove when powsybl core handles it, probably release of june 2026
         Line newLine1 = network.getLine(modificationInfos.getReplacingLine1Id());
         copyOperationalLimitsForOneLine(newLine1, operationalLimitsGroups1Line1, operationalLimitsGroups2Line1,
                 selectedOperationalLimitsGroup1Line1, selectedOperationalLimitsGroup2Line1);

--- a/src/main/java/org/gridsuite/modification/modifications/LinesAttachToSplitLines.java
+++ b/src/main/java/org/gridsuite/modification/modifications/LinesAttachToSplitLines.java
@@ -9,14 +9,19 @@ package org.gridsuite.modification.modifications;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.modification.topology.ReplaceTeePointByVoltageLevelOnLine;
 import com.powsybl.iidm.modification.topology.ReplaceTeePointByVoltageLevelOnLineBuilder;
+import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.OperationalLimitsGroup;
 import com.powsybl.iidm.network.VoltageLevel;
 import org.gridsuite.modification.NetworkModificationException;
 import org.gridsuite.modification.dto.LinesAttachToSplitLinesInfos;
 import org.gridsuite.modification.utils.ModificationUtils;
 
+import java.util.Collection;
+
 import static org.gridsuite.modification.NetworkModificationException.Type.LINE_ALREADY_EXISTS;
 import static org.gridsuite.modification.NetworkModificationException.Type.LINE_NOT_FOUND;
+import static org.gridsuite.modification.utils.ModificationUtils.copyOperationalLimitsForOneLine;
 
 /**
  * @author David Braquart <david.braquart at rte-france.com>
@@ -54,6 +59,17 @@ public class LinesAttachToSplitLines extends AbstractModification {
 
     @Override
     public void apply(Network network, ReportNode subReportNode) {
+        Line line1 = network.getLine(modificationInfos.getLineToAttachTo1Id());
+        String selectedOperationalLimitsGroup1Line1 = line1.getSelectedOperationalLimitsGroupId1().orElse(null);
+        String selectedOperationalLimitsGroup2Line1 = line1.getSelectedOperationalLimitsGroupId2().orElse(null);
+        Collection<OperationalLimitsGroup> operationalLimitsGroups1Line1 = line1.getOperationalLimitsGroups1();
+        Collection<OperationalLimitsGroup> operationalLimitsGroups2Line1 = line1.getOperationalLimitsGroups2();
+
+        Line line2 = network.getLine(modificationInfos.getLineToAttachTo2Id());
+        String selectedOperationalLimitsGroup1Line2 = line2.getSelectedOperationalLimitsGroupId1().orElse(null);
+        String selectedOperationalLimitsGroup2Line2 = line2.getSelectedOperationalLimitsGroupId2().orElse(null);
+        Collection<OperationalLimitsGroup> operationalLimitsGroups1Line2 = line2.getOperationalLimitsGroups1();
+        Collection<OperationalLimitsGroup> operationalLimitsGroups2Line2 = line2.getOperationalLimitsGroups2();
         ReplaceTeePointByVoltageLevelOnLine algo = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1(modificationInfos.getLineToAttachTo1Id())
                 .withTeePointLine2(modificationInfos.getLineToAttachTo2Id())
@@ -65,6 +81,12 @@ public class LinesAttachToSplitLines extends AbstractModification {
                 .withNewLine2Name(modificationInfos.getReplacingLine2Name())
                 .build();
         algo.apply(network, true, subReportNode);
+        Line newLine1 = network.getLine(modificationInfos.getReplacingLine1Id());
+        copyOperationalLimitsForOneLine(newLine1, operationalLimitsGroups1Line1, operationalLimitsGroups2Line1,
+                selectedOperationalLimitsGroup1Line1, selectedOperationalLimitsGroup2Line1);
+        Line newLine2 = network.getLine(modificationInfos.getReplacingLine2Id());
+        copyOperationalLimitsForOneLine(newLine2, operationalLimitsGroups1Line2, operationalLimitsGroups2Line2,
+                selectedOperationalLimitsGroup1Line2, selectedOperationalLimitsGroup2Line2);
     }
 
     @Override

--- a/src/test/java/org/gridsuite/modification/modifications/LinesAttachToSplitLinesTest.java
+++ b/src/test/java/org/gridsuite/modification/modifications/LinesAttachToSplitLinesTest.java
@@ -7,16 +7,20 @@
 package org.gridsuite.modification.modifications;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
 import org.gridsuite.modification.NetworkModificationException;
 import org.gridsuite.modification.dto.LinesAttachToSplitLinesInfos;
 import org.gridsuite.modification.dto.ModificationInfos;
 import org.gridsuite.modification.utils.NetworkWithTeePoint;
+
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.gridsuite.modification.NetworkModificationException.Type.LINE_ALREADY_EXISTS;
 import static org.gridsuite.modification.NetworkModificationException.Type.LINE_NOT_FOUND;
+import static org.gridsuite.modification.utils.TestUtils.checkLimitsGroupOnLine;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -49,15 +53,22 @@ class LinesAttachToSplitLinesTest extends AbstractNetworkModificationTest {
     @Override
     protected void assertAfterNetworkModificationApplication() {
         // 3 lines are gone
-        assertNull(getNetwork().getLine("l1"));
-        assertNull(getNetwork().getLine("l2"));
-        assertNull(getNetwork().getLine("l3"));
+        Network network = getNetwork();
+        assertNull(network.getLine("l1"));
+        assertNull(network.getLine("l2"));
+        assertNull(network.getLine("l3"));
         // v2 is gone
-        assertNull(getNetwork().getVoltageLevel("v2"));
+        assertNull(network.getVoltageLevel("v2"));
         assertEquals(3, getNetwork().getVoltageLevelCount());
         // new lines:
-        assertNotNull(getNetwork().getLine("nl1"));
-        assertNotNull(getNetwork().getLine("nl2"));
+        assertNotNull(network.getLine("nl1"));
+        assertNotNull(network.getLine("nl2"));
+
+        // check limits group are well copied
+        Line nl1 = network.getLine("nl1");
+        Line nl2 = network.getLine("nl2");
+        checkLimitsGroupOnLine(nl1, "group0", "group0", List.of("group0", "group1", "group2"), List.of("group0", "group1", "group2", "group3"));
+        checkLimitsGroupOnLine(nl2, "group0", "group0", List.of("group0", "group1", "group2"), List.of("group0", "group1", "group2", "group3"));
     }
 
     @Override


### PR DESCRIPTION
## PR Summary
- when using LinesAttachToSplitLines modification limits are now copied on the new lines
- this is temporary while powsybl core does not fix it



