### PR TITLE
fix: default modification activated flag to true at creation only

### DIFF
--- a/src/main/java/org/gridsuite/modification/dto/ModificationInfos.java
+++ b/src/main/java/org/gridsuite/modification/dto/ModificationInfos.java
@@ -115,9 +115,8 @@ public class ModificationInfos {
     @Schema(description = "Message values")
     private String messageValues;
 
-    @Schema(description = "Modification activated")
-    @Builder.Default
-    private Boolean activated = true;
+    @Schema(description = "Modification activated (defaults to true at creation when not provided)")
+    private Boolean activated;
 
     @Schema(description = "User description")
     private String description;

--- a/src/test/java/org/gridsuite/modification/modifications/CompositeModificationsTest.java
+++ b/src/test/java/org/gridsuite/modification/modifications/CompositeModificationsTest.java
@@ -142,6 +142,7 @@ class CompositeModificationsTest extends AbstractNetworkModificationTest {
     protected ModificationInfos buildModification() {
         List<ModificationInfos> modifications = List.of(
                 CompositeModificationInfos.builder()
+                        .activated(true)
                         .name("sub composite 1")
                         .modificationsInfos(
                                 List.of(
@@ -155,10 +156,12 @@ class CompositeModificationsTest extends AbstractNetworkModificationTest {
                 ModificationCreation.getCreationBattery("v1", "idBattery", "nameBattery", "1.1"),
                 // test of a composite modification inside a composite modification inside a composite modification
                 CompositeModificationInfos.builder()
+                        .activated(true)
                         .name("sub composite 2")
                         .modificationsInfos(
                                 List.of(
                                         CompositeModificationInfos.builder()
+                                                .activated(true)
                                                 .name("sub sub composite")
                                                 .modificationsInfos(
                                                         List.of(ModificationCreation.getModificationGenerator("idGenerator", "other idGenerator name again"))

--- a/src/test/java/org/gridsuite/modification/modifications/TwoWindingsTransformerCreationNodeBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/modifications/TwoWindingsTransformerCreationNodeBreakerTest.java
@@ -221,6 +221,7 @@ class TwoWindingsTransformerCreationNodeBreakerTest extends AbstractNetworkModif
                 .build();
         testCreateTwoWindingsTransformerInNodeBreaker(twoWindingsTransformerCreationInfos);
         TwoWindingsTransformerCreationInfos twoWindingsTransformerCreationInfos2 = TwoWindingsTransformerCreationInfos.builder()
+                .activated(true)
                 .equipmentId("id2wt1WithRatioTapChanger2")
                 .equipmentName("2wtName")
                 .description("a dummy description")

--- a/src/test/java/org/gridsuite/modification/utils/ModificationCreation.java
+++ b/src/test/java/org/gridsuite/modification/utils/ModificationCreation.java
@@ -28,6 +28,7 @@ public final class ModificationCreation {
     public static VoltageLevelCreationInfos getCreationVoltageLevel(String substationId, String voltageLevelId, String voltageLevelName) {
         return VoltageLevelCreationInfos.builder()
             .stashed(false)
+            .activated(true)
             .equipmentId(voltageLevelId)
             .equipmentName(voltageLevelName)
             .substationId(substationId)
@@ -45,6 +46,7 @@ public final class ModificationCreation {
     public static BatteryCreationInfos getCreationBattery(String vlId, String batteryId, String batteryName, String busOrBusbarSectionId) {
         return BatteryCreationInfos.builder()
                 .stashed(false)
+                .activated(true)
                 .equipmentId(batteryId)
                 .equipmentName(batteryName)
                 .voltageLevelId(vlId)
@@ -69,6 +71,7 @@ public final class ModificationCreation {
                                                               String regulatingTerminalId, String regulatingTerminalType, String regulatingTerminalVlId) {
         return GeneratorCreationInfos.builder()
             .stashed(false)
+            .activated(true)
             .equipmentId(generatorId)
             .equipmentName(generatorName)
             .voltageLevelId(vlId)
@@ -102,6 +105,7 @@ public final class ModificationCreation {
     public static GeneratorModificationInfos getModificationGenerator(String generatorId, String generatorName) {
         GeneratorModificationInfos.GeneratorModificationInfosBuilder builder = GeneratorModificationInfos.builder()
                 .stashed(false)
+                .activated(true)
                 .equipmentId(generatorId);
 
         if (generatorName != null) {
@@ -114,6 +118,7 @@ public final class ModificationCreation {
     public static LoadCreationInfos getCreationLoad(String vlId, String loadId, String loadName, String busOrBusBarSectionId, LoadType loadType) {
         return LoadCreationInfos.builder()
             .stashed(false)
+            .activated(true)
             .equipmentId(loadId)
             .equipmentName(loadName)
             .voltageLevelId(vlId)
@@ -129,6 +134,7 @@ public final class ModificationCreation {
     public static LoadModificationInfos getModificationLoad(String loadId, String vlId, String loadName, String busOrBusbarSectionId, LoadType loadType, Long activePower, Long reactivePower) {
         LoadModificationInfos.LoadModificationInfosBuilder builder = LoadModificationInfos.builder()
             .stashed(false)
+            .activated(true)
             .equipmentId(loadId);
 
         if (loadName != null) {
@@ -161,6 +167,7 @@ public final class ModificationCreation {
     public static VoltageLevelModificationInfos getModificationVoltageLevel(String vlId, String vlName) {
         VoltageLevelModificationInfos.VoltageLevelModificationInfosBuilder builder = VoltageLevelModificationInfos.builder()
             .stashed(false)
+            .activated(true)
             .equipmentId(vlId);
 
         builder.equipmentName(AttributeModification.toAttributeModification(vlName, OperationType.SET));


### PR DESCRIPTION
The `activated` field of `ModificationInfos` defaulted to `true` (field initializer + `@Builder.Default`), so after JSON deserialization it was never `null` when omitted from a request.

As a consequence, the null guard `if (metadata.getActivated() != null)` in `updateNetworkModificationMetadata` (network-modification-server) was always satisfied, silently reactivating a deactivated modification when editing it without sending the field.

## Change

- `activated` now defaults to `null` in the DTO.
- The `true` default must be applied at creation only (handled on the server side in the `ModificationEntity(ModificationInfos)` constructor).

This way, sending `null` on update leaves the activation status unchanged, while a creation without the field still produces an activated modification.